### PR TITLE
Update woocommerce-gateway-payco.php

### DIFF
--- a/woocommerce-gateway-payco.php
+++ b/woocommerce-gateway-payco.php
@@ -22,7 +22,7 @@ if (!defined('WPINC')) {
 
 require_once(dirname(__FILE__) . '/lib/EpaycoOrder.php');
 //require_once(dirname(__FILE__) . '/style.css');
-if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
+if (is_plugin_active( 'woocommerce/woocommerce.php' )) {
     add_action('plugins_loaded', 'init_epayco_woocommerce', 0);
     function init_epayco_woocommerce()
     {


### PR DESCRIPTION
La forma correcta para validar si un plugin está activo o no es por medio de la función is_plugin_active(), ya que el plugin podrían estar instalado para la red en una instalación multisitio de WordPress y no aparece en el listado de active_plugins.