### PR TITLE
Remove stock restoration on discount update

### DIFF
--- a/classes/class-wc-transaction-epayco.php
+++ b/classes/class-wc-transaction-epayco.php
@@ -108,7 +108,6 @@ class Epayco_Transaction_Handler {
         
             if (!EpaycoOrder::ifStockDiscount($order_id)) {
                 EpaycoOrder::updateStockDiscount($order_id, 1);
-                self::restore_stock($order_id, 'decrease');
                 // $order->add_order_note(__('Stock descontado - Pago aprobado', 'woo-epayco-gateway'));
                 $order->save();
             }


### PR DESCRIPTION
Remove the line to avoid double discounts, as this  affects product stock levels.